### PR TITLE
refactor: update project configuration plugin, resolve build warnings

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -11,6 +11,9 @@ projectConfiguration {
 dependencies {
     api(project(":common"))
 
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.18.3"))
+    implementation(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+
     implementation(platform("io.github.openfeign:feign-bom:13.5"))
     implementation(group = "io.github.openfeign", name = "feign-core")
     implementation(group = "io.github.openfeign", name = "feign-jackson")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,11 @@
 plugins {
-    `java-library`
-    id("me.philippheuer.configuration") version "0.15.2"
+    id("me.philippheuer.configuration") version "0.16.3"
 }
 
 version = properties["version"] as String
 
 allprojects {
     apply(plugin = "me.philippheuer.configuration")
-    apply(plugin = "java-library")
 
     repositories {
         mavenCentral()
@@ -18,7 +16,7 @@ allprojects {
         type.set(me.philippheuer.projectcfg.domain.ProjectType.LIBRARY)
         javaVersion.set(JavaVersion.VERSION_17)
         artifactGroupId.set("io.github.iprodigy.bttv")
-        javadocLombok.set(false)
+        disablePluginModules = listOf("DependencyReport", "LombokFeature")
 
         pom = {
             it.url.set("https://github.com/iProdigy/bttv4j")
@@ -49,21 +47,7 @@ allprojects {
         }
     }
 
-    dependencies {
-        api(group = "org.jspecify", name = "jspecify", version = "1.0.0")
-
-        implementation(platform("org.slf4j:slf4j-bom:2.0.17"))
-        api(group = "org.slf4j", name = "slf4j-api")
-        testImplementation(group = "org.slf4j", name = "slf4j-simple")
-
-        implementation(platform("com.fasterxml.jackson:jackson-bom:2.18.3"))
-        implementation(group = "com.fasterxml.jackson.core", name = "jackson-databind")
-        implementation(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
-
-        implementation(group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0")
-    }
-
-    tasks.test {
+    tasks.withType<Test> {
         useJUnitPlatform {
             includeTags("unittest")
             excludeTags("integration")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -7,3 +7,17 @@ projectConfiguration {
     artifactDisplayName.set("Bttv4J Common")
     artifactDescription.set("BetterTTV4J Common")
 }
+
+dependencies {
+    api(group = "org.jspecify", name = "jspecify", version = "1.0.0")
+
+    implementation(platform("org.slf4j:slf4j-bom:2.0.17"))
+    api(group = "org.slf4j", name = "slf4j-api")
+    testImplementation(group = "org.slf4j", name = "slf4j-simple")
+
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.18.3"))
+    implementation(group = "com.fasterxml.jackson.core", name = "jackson-databind")
+    implementation(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+
+    implementation(group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0")
+}

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module bttv4j.common {
     requires transitive com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.datatype.jsr310;
+    requires static kotlin.stdlib; // https://github.com/square/okhttp/issues/8194
     requires static okhttp3; // for SharedResources
     requires static org.jspecify;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.0.0
+version=1.0.0
 repository.publish.target=mavencentral

--- a/websocket/build.gradle.kts
+++ b/websocket/build.gradle.kts
@@ -12,6 +12,12 @@ projectConfiguration {
 dependencies {
     api(project(":common"))
 
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.18.3"))
+    implementation(group = "com.fasterxml.jackson.core", name = "jackson-databind")
+    implementation(group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310")
+
+    implementation(group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0")
+
     api(platform("com.github.philippheuer.events4j:events4j-bom:0.12.2"))
     api(group = "com.github.philippheuer.events4j", name = "events4j-api")
     implementation(group = "com.github.philippheuer.events4j", name = "events4j-core")
@@ -19,6 +25,8 @@ dependencies {
 }
 
 extraJavaModuleInfo {
+    skipLocalJars.set(true)
+
     automaticModule("org.jetbrains.kotlin:kotlin-stdlib-common", "kotlin.stdlib")
     automaticModule("org.jetbrains:annotations", "org.jetbrains.annotations")
 


### PR DESCRIPTION
* update `me.philippheuer.configuration` to `0.16.3`
* remove `java-library` from root project
* disable plugin modules that were causing warnings
* update module-info to workaround https://redirect.github.com/square/okhttp/issues/8194
